### PR TITLE
Modify parsing to ignore non-significant spaces

### DIFF
--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -195,6 +195,18 @@ namespace ini
         char fieldSep_;
         char comment_;
 
+        static void trim(std::string &str)
+        {
+            size_t startpos = str.find_first_not_of(" \t");
+            if(std::string::npos != startpos)
+            {
+                size_t endpos = str.find_last_not_of(" \t");
+                str = str.substr(startpos, endpos - startpos + 1);
+            }
+            else
+                str = "";
+        }
+
     public:
         IniFile() : IniFile('=', '#')
         {}
@@ -242,6 +254,7 @@ namespace ini
             {
                 std::string line;
                 std::getline(is, line, '\n');
+                trim(line);
                 ++lineNo;
 
                 // skip if line is empty
@@ -307,7 +320,9 @@ namespace ini
                     }
                     // retrieve field name and value
                     std::string name = line.substr(0, pos);
+                    trim(name);
                     std::string value = line.substr(pos + 1, std::string::npos);
+                    trim(value);
                     (*currentSection)[name] = value;
                 }
             }

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -225,3 +225,28 @@ TEST_CASE("fail to parse field without section", "IniFile")
     ini::IniFile inif;
     REQUIRE_THROWS(inif.decode("bar=bla"));
 }
+
+TEST_CASE("spaces are not taken into account in field names", "IniFile")
+{
+    std::istringstream ss(("[Foo]\n  \t  bar  \t  =hello world"));
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif["Foo"].find("bar") != inif["Foo"].end());
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "hello world");
+}
+
+TEST_CASE("spaces are not taken into account in field values", "IniFile")
+{
+    std::istringstream ss(("[Foo]\nbar=  \t  hello world  \t  "));
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "hello world");
+}
+
+TEST_CASE("spaces are not taken into account in sections", "IniFile")
+{
+    std::istringstream ss("  \t  [Foo]  \t  \nbar=bla");
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif.find("Foo") != inif.end());
+}


### PR DESCRIPTION
Many INI files are edited directly by end users, and some of them want to use spaces to make the contents easy to read.

For example:
```
[SECT1]
  #This comment is indented, as is the following lines, which are also aligned
  John   = 1
  Evelyn = 2
  Lucas  = 3
```

This pull request modifies the parser to ignore those non-significant spaces.
