### PR TITLE
Disallow section duplication

### DIFF
--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -295,6 +295,16 @@ namespace ini
 
                     // retrieve section name
                     std::string secName = line.substr(1, pos - 1);
+                    // check if the name of the section is already in use
+                    auto search = find(secName);
+                    if(search != end())
+                    {
+                        std::stringstream ss;
+                        ss << "l" << lineNo
+                           << ": ini parsing failed, duplicate section "
+                           << secName;
+                        throw std::logic_error(ss.str());
+                    }
                     currentSection = &((*this)[secName]);
                 }
                 else

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -250,3 +250,9 @@ TEST_CASE("spaces are not taken into account in sections", "IniFile")
 
     REQUIRE(inif.find("Foo") != inif.end());
 }
+
+TEST_CASE("fail to parse duplicate sections", "IniFile")
+{
+    ini::IniFile inif;
+    REQUIRE_THROWS(inif.decode("[Foo]\nbar=bla\n[Foo]\nbaz=ble\n"));
+}

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -251,7 +251,7 @@ TEST_CASE("spaces are not taken into account in sections", "IniFile")
     REQUIRE(inif.find("Foo") != inif.end());
 }
 
-TEST_CASE("fail to parse duplicate sections", "IniFile")
+TEST_CASE("fail to parse duplicated sections", "IniFile")
 {
     ini::IniFile inif;
     REQUIRE_THROWS(inif.decode("[Foo]\nbar=bla\n[Foo]\nbaz=ble\n"));


### PR DESCRIPTION
Right now a section is allowed to appear several times in an INI file:
```
[Foo]
var1 = hi
[Bar]
var2 = 12
[Foo]
var3 = 14
```
The section "[Foo]" will end up having var1 and var3.

This behaviour is unexpected and prone to error, so this pull request prevents files formed in this way by raising an exception.

Technically, this change is not retro-compatible, as INI files that worked so far will stop working, but in my opinion it is very strange that someone uses INI files duplicating sections, so it should not be very problematic.