### PR TITLE
Allow inline (trailing) comments in INI files

### DIFF
--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -207,6 +207,13 @@ namespace ini
                 str = "";
         }
 
+        void erase_comment(std::string &str)
+        {
+            size_t startpos = str.find(comment_);
+            if(std::string::npos != startpos)
+                str = str.substr(0, startpos);
+        }
+
     public:
         IniFile() : IniFile('=', '#')
         {}
@@ -254,14 +261,12 @@ namespace ini
             {
                 std::string line;
                 std::getline(is, line, '\n');
+                erase_comment(line);
                 trim(line);
                 ++lineNo;
 
                 // skip if line is empty
                 if(line.size() == 0)
-                    continue;
-                // skip if line is a comment
-                if(line[0] == comment_)
                     continue;
                 if(line[0] == '[')
                 {

--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -208,7 +208,7 @@ namespace ini
                 str = "";
         }
 
-        void erase_comment(std::string &str)
+        void eraseComment(std::string &str)
         {
             size_t startpos = str.find(comment_);
             if(std::string::npos == startpos)
@@ -272,7 +272,7 @@ namespace ini
             {
                 std::string line;
                 std::getline(is, line, '\n');
-                erase_comment(line);
+                eraseComment(line);
                 trim(line);
                 ++lineNo;
 

--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -193,7 +193,7 @@ namespace ini
     {
     private:
         char fieldSep_;
-        std::string comment_;
+        char comment_;
 
         static void trim(std::string &str)
         {
@@ -219,10 +219,6 @@ namespace ini
         {}
 
         IniFile(const char fieldSep, const char comment)
-            : fieldSep_(fieldSep), comment_(1, comment)
-        {}
-
-        IniFile(const char fieldSep, const std::string &comment)
             : fieldSep_(fieldSep), comment_(comment)
         {}
 
@@ -234,25 +230,9 @@ namespace ini
             load(filename);
         }
 
-        IniFile(const std::string &filename,
-            const char fieldSep,
-            const std::string &comment)
-            : IniFile(fieldSep, comment)
-        {
-            load(filename);
-        }
-
         IniFile(std::istream &is,
             const char fieldSep = '=',
             const char comment = '#')
-            : IniFile(fieldSep, comment)
-        {
-            decode(is);
-        }
-
-        IniFile(std::istream &is,
-            const char fieldSep,
-            const std::string &comment)
             : IniFile(fieldSep, comment)
         {
             decode(is);

--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -194,6 +194,7 @@ namespace ini
     private:
         char fieldSep_;
         char comment_;
+        char escape_;
 
         static void trim(std::string &str)
         {
@@ -210,8 +211,18 @@ namespace ini
         void erase_comment(std::string &str)
         {
             size_t startpos = str.find(comment_);
-            if(std::string::npos != startpos)
-                str = str.substr(0, startpos);
+            if(std::string::npos == startpos)
+                return;
+            // Found a comment prefix, is it escaped?
+            if(0 != startpos && str[startpos - 1] == escape_)
+            {
+                // The comment prefix is escaped, so just delete the escape char
+                str.erase(startpos - 1, 1);
+            }
+            else
+            {
+                str.erase(startpos);
+            }
         }
 
     public:
@@ -219,7 +230,7 @@ namespace ini
         {}
 
         IniFile(const char fieldSep, const char comment)
-            : fieldSep_(fieldSep), comment_(comment)
+            : fieldSep_(fieldSep), comment_(comment), escape_('\\')
         {}
 
         IniFile(const std::string &filename,

--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -193,7 +193,7 @@ namespace ini
     {
     private:
         char fieldSep_;
-        char comment_;
+        std::string comment_;
 
         static void trim(std::string &str)
         {
@@ -219,6 +219,10 @@ namespace ini
         {}
 
         IniFile(const char fieldSep, const char comment)
+            : fieldSep_(fieldSep), comment_(1, comment)
+        {}
+
+        IniFile(const char fieldSep, const std::string &comment)
             : fieldSep_(fieldSep), comment_(comment)
         {}
 
@@ -230,9 +234,25 @@ namespace ini
             load(filename);
         }
 
+        IniFile(const std::string &filename,
+            const char fieldSep,
+            const std::string &comment)
+            : IniFile(fieldSep, comment)
+        {
+            load(filename);
+        }
+
         IniFile(std::istream &is,
             const char fieldSep = '=',
             const char comment = '#')
+            : IniFile(fieldSep, comment)
+        {
+            decode(is);
+        }
+
+        IniFile(std::istream &is,
+            const char fieldSep,
+            const std::string &comment)
             : IniFile(fieldSep, comment)
         {
             decode(is);

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -124,6 +124,16 @@ TEST_CASE("parse with comment", "IniFile")
     REQUIRE(inif["Foo"]["bar"].as<std::string>() == "bla");
 }
 
+TEST_CASE("parse with multi char comment", "IniFile")
+{
+    std::istringstream ss("[Foo]\nREM this is a test\nbar=bla");
+    ini::IniFile inif(ss, '=', "REM");
+
+    REQUIRE(inif.size() == 1);
+    REQUIRE(inif["Foo"].size() == 1);
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "bla");
+}
+
 TEST_CASE("parse with custom comment char", "IniFile")
 {
     std::istringstream ss("[Foo]\n$ this is a test\nbar=bla");

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -184,10 +184,29 @@ TEST_CASE("inline comments in sections are discarded", "IniFile")
 
 TEST_CASE("inline comments in fields are discarded", "IniFile")
 {
-    std::istringstream ss("[Foo]\nbar=Hello world! # This is an inline comment");
+    std::istringstream ss("[Foo]\n"
+                          "bar=Hello #world!");
     ini::IniFile inif(ss);
 
-    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello world!");
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello");
+}
+
+TEST_CASE("inline comments can be escaped", "IniFile")
+{
+    std::istringstream ss("[Foo]\n"
+                          "bar=Hello \\#world!");
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello #world!");
+}
+
+TEST_CASE("escape characters are kept if not before a comment prefix", "IniFile")
+{
+    std::istringstream ss("[Foo]\n"
+                          "bar=Hello \\world!");
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello \\world!");
 }
 
 /***************************************************

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -250,3 +250,19 @@ TEST_CASE("spaces are not taken into account in sections", "IniFile")
 
     REQUIRE(inif.find("Foo") != inif.end());
 }
+
+TEST_CASE("inline comments in sections are discarded", "IniFile")
+{
+    std::istringstream ss("[Foo] # This is an inline comment\nbar=Hello world!");
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif.find("Foo") != inif.end());
+}
+
+TEST_CASE("inline comments in fields are discarded", "IniFile")
+{
+    std::istringstream ss("[Foo]\nbar=Hello world! # This is an inline comment");
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello world!");
+}

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -124,16 +124,6 @@ TEST_CASE("parse with comment", "IniFile")
     REQUIRE(inif["Foo"]["bar"].as<std::string>() == "bla");
 }
 
-TEST_CASE("parse with multi char comment", "IniFile")
-{
-    std::istringstream ss("[Foo]\nREM this is a test\nbar=bla");
-    ini::IniFile inif(ss, '=', "REM");
-
-    REQUIRE(inif.size() == 1);
-    REQUIRE(inif["Foo"].size() == 1);
-    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "bla");
-}
-
 TEST_CASE("parse with custom comment char", "IniFile")
 {
     std::istringstream ss("[Foo]\n$ this is a test\nbar=bla");
@@ -182,6 +172,22 @@ TEST_CASE("save with custom field sep", "IniFile")
 
     std::string result = inif.encode();
     REQUIRE(result == "[Foo]\nbar1:true\nbar2:false\n");
+}
+
+TEST_CASE("inline comments in sections are discarded", "IniFile")
+{
+    std::istringstream ss("[Foo] # This is an inline comment\nbar=Hello world!");
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif.find("Foo") != inif.end());
+}
+
+TEST_CASE("inline comments in fields are discarded", "IniFile")
+{
+    std::istringstream ss("[Foo]\nbar=Hello world! # This is an inline comment");
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello world!");
 }
 
 /***************************************************
@@ -259,20 +265,4 @@ TEST_CASE("spaces are not taken into account in sections", "IniFile")
     ini::IniFile inif(ss);
 
     REQUIRE(inif.find("Foo") != inif.end());
-}
-
-TEST_CASE("inline comments in sections are discarded", "IniFile")
-{
-    std::istringstream ss("[Foo] # This is an inline comment\nbar=Hello world!");
-    ini::IniFile inif(ss);
-
-    REQUIRE(inif.find("Foo") != inif.end());
-}
-
-TEST_CASE("inline comments in fields are discarded", "IniFile")
-{
-    std::istringstream ss("[Foo]\nbar=Hello world! # This is an inline comment");
-    ini::IniFile inif(ss);
-
-    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello world!");
 }


### PR DESCRIPTION
Inline or trailing comments as these ones:
```
[Foo] # This is an inline comment
bar=Hello world! # This is another inline comment
```
are a handy feature often requested by end clients.

Although there is [no standard on this](https://en.wikipedia.org/wiki/INI_file#Comments), I think they would be a good feature for the library.

This pull request implements such a feature.