### PR TITLE
Multiple string comment prefixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 .project
 .cproject
 .settings
+.vscode 

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -174,6 +174,31 @@ TEST_CASE("comment prefixes can be set after construction", "IniFile")
     REQUIRE(inif["Foo"]["bar"].as<std::string>() == "bla");
 }
 
+TEST_CASE("comments are allowed after escaped comments", "IniFile")
+{
+    std::istringstream ss("[Foo]\n"
+                          "hello=world \\## this is a comment\n"
+                          "more=of this \\# \\#\n");
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif["Foo"]["hello"].as<std::string>() == "world #");
+    REQUIRE(inif["Foo"]["more"].as<std::string>() == "of this # #");
+}
+
+TEST_CASE(
+    "escape char right before a comment prefix escapes all the comment prefix",
+    "IniFile")
+{
+    std::istringstream ss("[Foo]\n"
+                          "weird1=note \\### this is not a comment\n"
+                          "weird2=but \\#### this is a comment");
+    ini::IniFile inif(ss, '=', {"##"});
+
+    REQUIRE(inif["Foo"]["weird1"].as<std::string>() ==
+            "note ### this is not a comment");
+    REQUIRE(inif["Foo"]["weird2"].as<std::string>() == "but ##");
+}
+
 TEST_CASE("save with bool fields", "IniFile")
 {
     ini::IniFile inif;

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -124,10 +124,50 @@ TEST_CASE("parse with comment", "IniFile")
     REQUIRE(inif["Foo"]["bar"].as<std::string>() == "bla");
 }
 
-TEST_CASE("parse with custom comment char", "IniFile")
+TEST_CASE("parse with custom comment char prefix", "IniFile")
 {
     std::istringstream ss("[Foo]\n$ this is a test\nbar=bla");
     ini::IniFile inif(ss, '=', '$');
+
+    REQUIRE(inif.size() == 1);
+    REQUIRE(inif["Foo"].size() == 1);
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "bla");
+}
+
+TEST_CASE("parse with multi char comment prefix", "IniFile")
+{
+    std::istringstream ss("[Foo]\nREM this is a test\nbar=bla");
+    ini::IniFile inif(ss, '=', {"REM"});
+
+    REQUIRE(inif.size() == 1);
+    REQUIRE(inif["Foo"].size() == 1);
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "bla");
+}
+
+TEST_CASE("parse with multiple multi char comment prefixes", "IniFile")
+{
+    std::istringstream ss("[Foo]\n"
+                          "REM this is a comment\n"
+                          "#Also a comment\n"
+                          "//Even this is a comment\n"
+                          "bar=bla");
+    ini::IniFile inif(ss, '=', {"REM", "#", "//"});
+
+    REQUIRE(inif.size() == 1);
+    REQUIRE(inif["Foo"].size() == 1);
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "bla");
+}
+
+TEST_CASE("comment prefixes can be set after construction", "IniFile")
+{
+    std::istringstream ss("[Foo]\n"
+                          "REM this is a comment\n"
+                          "#Also a comment\n"
+                          "//Even this is a comment\n"
+                          "bar=bla");
+    ini::IniFile inif;
+    inif.setCommentPrefixes({"REM", "#", "//"});
+    inif.decode(ss);
 
     REQUIRE(inif.size() == 1);
     REQUIRE(inif["Foo"].size() == 1);


### PR DESCRIPTION
I think it is a good idea to have multiple comment prefixes. Some end users, for example, want to use both # and ; as comment prefixes.

Other end users want to use multi character comment prefixes like // and REM.

This pull request allows both of that. So, for example, given
`ini::IniFile inif(ss, '=', {"REM", "#", "//"});`
then this file will be parsed as expected:

```
[Foo]
  REM This is a comment
  # Also a comment
  // Even this is a comment
  bar = bla // And comments can also be inlined
  baz = \//This is not a comment as it is escaped
```

inif["Foo"]["bar"] will return "bla", but inif["Foo"]["baz"] will return "//This is not a comment as it is escaped".


