### PR TITLE
Fix missing include file

### DIFF
--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <sstream>
 #include <stdexcept>
+#include <vector>
 
 namespace ini
 {

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -6,8 +6,8 @@
  *    License: MIT
  */
 
-#include <catch.hpp>
 #include "inicpp.h"
+#include <catch.hpp>
 
 #include <sstream>
 


### PR DESCRIPTION
`inicpp.h` has added a member of type `std::vector` to `ini::IniFile` classs in pull request #17 but has not added `#include <vector>`.

This results in compilation errors in case `inicpp.h` is the first file included in a compilation unit.

This pull request fixes the problem but also reorder the includes of `test_inifile.cpp` so that similar errors are easily found.