### PR TITLE
Add support for multi-line values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ int main()
 }
 ```
 
+You can enable decoding of multi-line values using the  ```setMultiLineValues(true)``` function.  If you do this, field values may be continued on the next line, after indentation.  Each line will be separated by the `\n` character in the final value, and the indentation will be removed.
+
+```cpp
+#include <inicpp.h>
+
+int main()
+{
+    // load an ini file
+    ini::IniFile myIni;
+    myIni.setMultiLineValues(true);
+    myIni.load("some/ini/path");
+}
+```
+
 Sections and fields can be accessed using the index operator ```[]```.
 The values can be converted to various native types:
 
@@ -212,3 +226,4 @@ Thanks to all contributors for extending, improving and fixing this small, but s
 * [rjungheinrich](https://github.com/rjungheinrich)
 * [JGJunghein](https://github.com/JGJunghein)
 * [antonioborondo](https://github.com/antonioborondo)
+* [jtikalsky](https://github.com/jtikalsky)

--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -601,14 +601,14 @@ namespace ini
             this->clear();
             int lineNo = 0;
             IniSectionBase<Comparator> *currentSection = nullptr;
-            std::string multiline_value_field_name = "";
+            std::string mutliLineValueFieldName = "";
             std::string line;
             // iterate file line by line
             while(!is.eof() && !is.fail())
             {
                 std::getline(is, line, '\n');
                 eraseComments(line);
-                bool has_indent = line.find_first_not_of(indents()) != 0;
+                bool hasIndent = line.find_first_not_of(indents()) != 0;
                 trim(line);
                 ++lineNo;
 
@@ -643,7 +643,7 @@ namespace ini
 
                     // clear multiline value field name
                     // a new section means there is no value to continue
-                    multiline_value_field_name = "";
+                    mutliLineValueFieldName = "";
                 }
                 else
                 {
@@ -659,12 +659,12 @@ namespace ini
 
                     // find key value separator
                     std::size_t pos = line.find(fieldSep_);
-                    if (multiLineValues_ && has_indent && multiline_value_field_name != "")
+                    if (multiLineValues_ && hasIndent && mutliLineValueFieldName != "")
                     {
                         // extend a multi-line value
-                        IniField previous_value = (*currentSection)[multiline_value_field_name];
+                        IniField previous_value = (*currentSection)[mutliLineValueFieldName];
                         std::string value = previous_value.as<std::string>() + "\n" + line;
-                        (*currentSection)[multiline_value_field_name] = value;
+                        (*currentSection)[mutliLineValueFieldName] = value;
                     }
                     else if(pos == std::string::npos)
                     {
@@ -686,7 +686,7 @@ namespace ini
                         trim(value);
                         (*currentSection)[name] = value;
                         // store last field name for potential multi-line values
-                        multiline_value_field_name = name;
+                        mutliLineValueFieldName = name;
                     }
                 }
             }

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -576,7 +576,9 @@ TEST_CASE("multi-line values are read correctly with space indents", "IniFile")
     std::istringstream ss("[Foo]\n"
                           "bar=Hello\n"
                           "    world!");
-    ini::IniFile inif(ss);
+    ini::IniFile inif;
+    inif.setMultiLineValues(true);
+    inif.decode(ss);
 
     REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello\nworld!");
 }
@@ -586,7 +588,9 @@ TEST_CASE("multi-line values are read correctly with tab indents", "IniFile")
     std::istringstream ss("[Foo]\n"
                           "bar=Hello\n"
                           "\tworld!");
-    ini::IniFile inif(ss);
+    ini::IniFile inif;
+    inif.setMultiLineValues(true);
+    inif.decode(ss);
 
     REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello\nworld!");
 }
@@ -596,7 +600,9 @@ TEST_CASE("multi-line values discard end-of-line comments", "IniFile")
     std::istringstream ss("[Foo]\n"
                           "bar=Hello ; everyone\n"
                           "    world! ; comment");
-    ini::IniFile inif(ss);
+    ini::IniFile inif;
+    inif.setMultiLineValues(true);
+    inif.decode(ss);
 
     REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello\nworld!");
 }
@@ -607,9 +613,53 @@ TEST_CASE("multi-line values discard interspersed comment lines", "IniFile")
                           "bar=Hello\n"
                           "; everyone\n"
                           "    world!");
-    ini::IniFile inif(ss);
+    ini::IniFile inif;
+    inif.setMultiLineValues(true);
+    inif.decode(ss);
 
     REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello\nworld!");
+}
+
+TEST_CASE("multi-line values should not be parsed when disabled", "IniFile")
+{
+    std::istringstream ss("[Foo]\n"
+                          "    bar=Hello\n"
+                          "    baz=world!");
+    ini::IniFile inif;
+    inif.setMultiLineValues(false);
+    inif.decode(ss);
+
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello");
+	REQUIRE(inif["Foo"]["baz"].as<std::string>() == "world!");
+}
+
+TEST_CASE("multi-line values should be parsed when enabled, even when the continuation contains =", "IniFile")
+{
+    std::istringstream ss("[Foo]\n"
+                          "    bar=Hello\n"
+                          "    baz=world!");
+    ini::IniFile inif;
+    inif.setMultiLineValues(true);
+    inif.decode(ss);
+
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello\nbaz=world!");
+	REQUIRE(inif["Foo"]["baz"].as<std::string>() == "");
+}
+
+TEST_CASE("when multi-line values are enabled, write newlines as multi-line value continuations", "IniFile")
+{
+    ini::IniFile inif;
+    inif.setMultiLineValues(true);
+
+    inif["Foo"] = ini::IniSection();
+    inif["Foo"]["bar"] = "Hello\nworld!";
+
+    std::string str = inif.encode();
+
+    REQUIRE(str ==
+            "[Foo]\n"
+            "bar=Hello\n"
+            "\tworld!\n");
 }
 
 TEST_CASE("stringInsensitiveLess operator() returns true if and only if first parameter is less than the second ignoring sensitivity", "StringInsensitiveLessFunctor")
@@ -685,9 +735,31 @@ TEST_CASE("fail to load field without equal", "IniFile")
     REQUIRE_THROWS(inif.decode("[Foo]\nbar"));
 }
 
-TEST_CASE("fail to continue multi-line field without start", "IniFile")
+TEST_CASE("fail to parse a multi-line field without indentation (when enabled)", "IniFile")
 {
     ini::IniFile inif;
+    inif.setMultiLineValues(true);
+    REQUIRE_THROWS(inif.decode("[Foo]\nbar=Hello\nworld!"));
+}
+
+TEST_CASE("fail to parse a multi-line field without indentation (when disabled)", "IniFile")
+{
+    ini::IniFile inif;
+    inif.setMultiLineValues(false);
+    REQUIRE_THROWS(inif.decode("[Foo]\nbar=Hello\nworld!"));
+}
+
+TEST_CASE("fail to continue multi-line field without start (when enabled)", "IniFile")
+{
+    ini::IniFile inif;
+    inif.setMultiLineValues(true);
+    REQUIRE_THROWS(inif.decode("[Foo]\n    world!\nbar=Hello"));
+}
+
+TEST_CASE("fail to continue multi-line field without start (when disabled)", "IniFile")
+{
+    ini::IniFile inif;
+    inif.setMultiLineValues(false);
     REQUIRE_THROWS(inif.decode("[Foo]\n    world!\nbar=Hello"));
 }
 

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -571,6 +571,47 @@ TEST_CASE("escape characters are kept if not before a comment prefix", "IniFile"
     REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello \\world!");
 }
 
+TEST_CASE("multi-line values are read correctly with space indents", "IniFile")
+{
+    std::istringstream ss("[Foo]\n"
+                          "bar=Hello\n"
+                          "    world!");
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello\nworld!");
+}
+
+TEST_CASE("multi-line values are read correctly with tab indents", "IniFile")
+{
+    std::istringstream ss("[Foo]\n"
+                          "bar=Hello\n"
+                          "\tworld!");
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello\nworld!");
+}
+
+TEST_CASE("multi-line values discard end-of-line comments", "IniFile")
+{
+    std::istringstream ss("[Foo]\n"
+                          "bar=Hello ; everyone\n"
+                          "    world! ; comment");
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello\nworld!");
+}
+
+TEST_CASE("multi-line values discard interspersed comment lines", "IniFile")
+{
+    std::istringstream ss("[Foo]\n"
+                          "bar=Hello\n"
+                          "; everyone\n"
+                          "    world!");
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "Hello\nworld!");
+}
+
 TEST_CASE("stringInsensitiveLess operator() returns true if and only if first parameter is less than the second ignoring sensitivity", "StringInsensitiveLessFunctor")
 {
     ini::StringInsensitiveLess cc;
@@ -642,6 +683,12 @@ TEST_CASE("fail to load field without equal", "IniFile")
 {
     ini::IniFile inif;
     REQUIRE_THROWS(inif.decode("[Foo]\nbar"));
+}
+
+TEST_CASE("fail to continue multi-line field without start", "IniFile")
+{
+    ini::IniFile inif;
+    REQUIRE_THROWS(inif.decode("[Foo]\n    world!\nbar=Hello"));
 }
 
 TEST_CASE("fail to parse as bool", "IniFile")


### PR DESCRIPTION
# Summary

This pull request adds support multi-line values, similar to what is done [here](https://docs.python.org/3/library/configparser.html#supported-ini-file-structure).  In this form, a line is a continuation of a previous value if it begins with whitespace indentation on a subsequent line.

# Examples

```ini
[Multiline Values]
chorus = I'm a lumberjack, and I'm okay
    I sleep all night and I work all day
```
is parsed as:
```cpp
"I'm a lumberjack, and I'm okay\nI sleep all night and I work all day"
```
---

```ini
[Multiline Values]
chorus = I'm a lumberjack, and I'm okay ; first phrase
    I sleep all night and I work all day ; second phrase
```
is parsed as:
```cpp
"I'm a lumberjack, and I'm okay\nI sleep all night and I work all day"
```

---

```ini
[Multiline Values]
chorus = I'm a lumberjack, and I'm okay ; first phrase
    ; this is still a comment
    I sleep all night and I work all day ; second phrase
```
is parsed as:
```cpp
"I'm a lumberjack, and I'm okay\nI sleep all night and I work all day"
```

---

```ini
[Multiline Values]
chorus = I'm a lumberjack, and I'm okay
I sleep all night and I work all day
```
is parsed as:
```cpp
"I'm a lumberjack, and I'm okay\nI sleep all night and I work all day"
```

# Compatibility Breaks

This change breaks compatibility with indented values.  I recognize this is a problem, and have discussed some potential solutions below.

```ini
[Indented Values]
    first = I'm a lumberjack, and I'm okay
second = I sleep all night and I work all day
```
is parsed as
```cpp
first = "I'm a lumberjack, and I'm okay";
second = "I sleep all night and I work all day";
```

where

```ini
[Indented Values]
    first = I'm a lumberjack, and I'm okay
    second = I sleep all night and I work all day
```
is parsed as
```cpp
first = "I'm a lumberjack, and I'm okay\nsecond = I sleep all night and I work all day";
```

# Potential Solutions

## 1. Setting

A setting to enable parsing of multi-line values may be useful.  It could default to `false` to maintain compatibility, and if toggled to `true`, it could enable parsing of multi-line values, and disable parsing of (throw on) indented field names (at the start of a section) for consistency.

Because this method retains compatibility with other libraries with similar functionality on other platforms, it is my strong preference.  I would be willing to provide an implementation for any of the setting-based options if desired.

### 1a. Constructor Argument

This could be implemented as an additional constructor argument.

I understand it may become somewhat unwieldy to add arguments for this sort of functionality, particularly if more come in the future.

### 1b. Template Parameter

This could be implemented as a template parameter to IniFileBase, with the parameter as `false` for the default IniFile type, and `true` for a new IniFileMultiline or similar type:

```cpp
template <typename Comparator, bool MULTILINE_VALUE> class IniFileBase...
using IniFile = IniFileBase<std::less<std::string>, false>;
using IniFileMultiline = IniFileBase<std::less<std::string>, true>;
```

### 1c. Configuration `#define`

This could be implemented as a configuration-style `#define`.  Some instances of this exist, including in C standard libraries to enable/disable certain special POSIX compatibility or other features (although I sadly can't remember an example right now).  In this case, something like the below example would change the behavior of the library.

```cpp
#define INICPP_MULTILINE_INCLUDES
#include "inicpp.h"
```

## 2. Special syntax

I dislike these options as they do not maintain compatibility with other libraries with similar functionality in other languages.  Nonetheless, they are possible.

### 2a. Line Continuation Character

Many syntaxes have a line-continuation character.  `\` immediately before the end of the line (i.e. `"\\\n"`) makes the next line a continuation of the current one, as shown:

```ini
[Multiline Values]
chorus = I'm a lumberjack, and I'm okay \
    I sleep all night and I work all day
```

This solution removes the possibility of including comments within the value.

### 2b. Require the value to be re-introduced on each line

It would be possible to require the value to be reintroduced on each line, by prefixing the field separator.

```ini
[Multiline Values]
chorus = I'm a lumberjack, and I'm okay
       = I sleep all night and I work all day
```

This is easily confused as some form of vector assignment.