### PR TITLE
Fix trimCopy function

### DIFF
--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -49,19 +49,6 @@ namespace ini
         str.erase(0, str.find_first_not_of(whitespaces()));
     }
 
-    /** Trims a string and returns the result as copy.
-      * @param str string to be trimmed
-      * @return trimmed string */
-    inline std::string trimCopy(const std::string &str)
-    {
-        auto firstpos = str.find_first_not_of(whitespaces());
-        if(firstpos == std::string::npos)
-            return "";
-
-        auto lastpos = str.find_last_not_of(whitespaces());
-        return str.substr(firstpos, lastpos - firstpos + 1);
-    }
-
     /************************************************
      * Conversion Functors
      ************************************************/

--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -59,7 +59,7 @@ namespace ini
             return "";
 
         auto lastpos = str.find_last_not_of(whitespaces());
-        return str.substr(firstpos, lastpos);
+        return str.substr(firstpos, lastpos - firstpos + 1);
     }
 
     /************************************************

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -628,7 +628,7 @@ TEST_CASE(".as<>() works with IniFileCaseInsensitive", "IniFile")
     REQUIRE(inif["FOO"]["bar"].as<std::string>() == "bla");
 }
 
-TEST_CASE("trim() works with empty strings", "TrimFunctions")
+TEST_CASE("trim() works with empty strings", "TrimFunction")
 {
     std::string example1 = "";
     std::string example2 = "  \t\n  ";
@@ -640,7 +640,7 @@ TEST_CASE("trim() works with empty strings", "TrimFunctions")
     REQUIRE(example2.size() == 0);
 }
 
-TEST_CASE("trim() works with already trimmed strings", "TrimFunctions")
+TEST_CASE("trim() works with already trimmed strings", "TrimFunction")
 {
     std::string example1 = "example_text";
     std::string example2 = "example  \t\n  text";
@@ -652,7 +652,7 @@ TEST_CASE("trim() works with already trimmed strings", "TrimFunctions")
     REQUIRE(example2 == "example  \t\n  text");
 }
 
-TEST_CASE("trim() works with untrimmed strings", "TrimFunctions")
+TEST_CASE("trim() works with untrimmed strings", "TrimFunction")
 {
     std::string example1 = "example text      ";
     std::string example2 = "      example text";
@@ -668,37 +668,6 @@ TEST_CASE("trim() works with untrimmed strings", "TrimFunctions")
     REQUIRE(example2 == "example text");
     REQUIRE(example3 == "example text");
     REQUIRE(example4 == "example  \t\n  text");
-}
-
-TEST_CASE("trimCopy() works with empty strings", "TrimFunctions")
-{
-    std::string example1 = "";
-    std::string example2 = "  \t\n  ";
-
-    REQUIRE(ini::trimCopy(example1).size() == 0);
-    REQUIRE(ini::trimCopy(example2).size() == 0);
-}
-
-TEST_CASE("trimCopy() works with already trimmed strings", "TrimFunctions")
-{
-    std::string example1 = "example_text";
-    std::string example2 = "example  \t\n  text";
-
-    REQUIRE(ini::trimCopy(example1) == "example_text");
-    REQUIRE(ini::trimCopy(example2) == "example  \t\n  text");
-}
-
-TEST_CASE("trimCopy() works with untrimmed strings", "TrimFunctions")
-{
-    std::string example1 = "example text      ";
-    std::string example2 = "      example text";
-    std::string example3 = "      example text      ";
-    std::string example4 = "  \t\n  example  \t\n  text  \t\n  ";
-
-    REQUIRE(ini::trimCopy(example1) == "example text");
-    REQUIRE(ini::trimCopy(example2) == "example text");
-    REQUIRE(ini::trimCopy(example3) == "example text");
-    REQUIRE(ini::trimCopy(example4) == "example  \t\n  text");
 }
 
 /***************************************************

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -628,6 +628,79 @@ TEST_CASE(".as<>() works with IniFileCaseInsensitive", "IniFile")
     REQUIRE(inif["FOO"]["bar"].as<std::string>() == "bla");
 }
 
+TEST_CASE("trim() works with empty strings", "TrimFunctions")
+{
+    std::string example1 = "";
+    std::string example2 = "  \t\n  ";
+
+    ini::trim(example1);
+    ini::trim(example2);
+
+    REQUIRE(example1.size() == 0);
+    REQUIRE(example2.size() == 0);
+}
+
+TEST_CASE("trim() works with already trimmed strings", "TrimFunctions")
+{
+    std::string example1 = "example_text";
+    std::string example2 = "example  \t\n  text";
+
+    ini::trim(example1);
+    ini::trim(example2);
+
+    REQUIRE(example1 == "example_text");
+    REQUIRE(example2 == "example  \t\n  text");
+}
+
+TEST_CASE("trim() works with untrimmed strings", "TrimFunctions")
+{
+    std::string example1 = "example text      ";
+    std::string example2 = "      example text";
+    std::string example3 = "      example text      ";
+    std::string example4 = "  \t\n  example  \t\n  text  \t\n  ";
+
+    ini::trim(example1);
+    ini::trim(example2);
+    ini::trim(example3);
+    ini::trim(example4);
+
+    REQUIRE(example1 == "example text");
+    REQUIRE(example2 == "example text");
+    REQUIRE(example3 == "example text");
+    REQUIRE(example4 == "example  \t\n  text");
+}
+
+TEST_CASE("trimCopy() works with empty strings", "TrimFunctions")
+{
+    std::string example1 = "";
+    std::string example2 = "  \t\n  ";
+
+    REQUIRE(ini::trimCopy(example1).size() == 0);
+    REQUIRE(ini::trimCopy(example2).size() == 0);
+}
+
+TEST_CASE("trimCopy() works with already trimmed strings", "TrimFunctions")
+{
+    std::string example1 = "example_text";
+    std::string example2 = "example  \t\n  text";
+
+    REQUIRE(ini::trimCopy(example1) == "example_text");
+    REQUIRE(ini::trimCopy(example2) == "example  \t\n  text");
+}
+
+TEST_CASE("trimCopy() works with untrimmed strings", "TrimFunctions")
+{
+    std::string example1 = "example text      ";
+    std::string example2 = "      example text";
+    std::string example3 = "      example text      ";
+    std::string example4 = "  \t\n  example  \t\n  text  \t\n  ";
+
+    REQUIRE(ini::trimCopy(example1) == "example text");
+    REQUIRE(ini::trimCopy(example2) == "example text");
+    REQUIRE(ini::trimCopy(example3) == "example text");
+    REQUIRE(ini::trimCopy(example4) == "example  \t\n  text");
+}
+
 /***************************************************
  *                Failing Tests
  ***************************************************/


### PR DESCRIPTION
In this line:
https://github.com/Rookfighter/inifile-cpp/blob/47734f1ab4ed1964842e552dace0a3d970a83b4f/include/inicpp.h#L62
function `trimCopy()` calls `substr()` with a range of positions, but it expects length of characters as a second parameter. This pull request fixes it and adds new unit tests. Also, I have noticed that `trimCopy()` is never actually called, so all other unit tests were passing.