### PR TITLE
Support parsing bool values from 1 and 0.

### DIFF
--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -111,9 +111,9 @@ namespace ini
                 return static_cast<char>(::toupper(c));
             });
 
-            if(str == "TRUE")
+            if(str == "TRUE" || str == "1")
                 result = true;
-            else if(str == "FALSE")
+            else if(str == "FALSE" || str == "0")
                 result = false;
             else
                 throw std::invalid_argument("field is not a bool");

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -69,14 +69,16 @@ TEST_CASE("parse section with duplicate field", "IniFile")
 
 TEST_CASE("parse field as bool", "IniFile")
 {
-    std::istringstream ss("[Foo]\nbar1=true\nbar2=false\nbar3=tRuE");
+    std::istringstream ss("[Foo]\nbar1=true\nbar2=false\nbar3=tRuE\nbar4=1\nbar5=0\n");
     ini::IniFile inif(ss);
 
     REQUIRE(inif.size() == 1);
-    REQUIRE(inif["Foo"].size() == 3);
+    REQUIRE(inif["Foo"].size() == 5);
     REQUIRE(inif["Foo"]["bar1"].as<bool>());
     REQUIRE_FALSE(inif["Foo"]["bar2"].as<bool>());
     REQUIRE(inif["Foo"]["bar3"].as<bool>());
+    REQUIRE(inif["Foo"]["bar4"].as<bool>());
+    REQUIRE_FALSE(inif["Foo"]["bar5"].as<bool>());
 }
 
 TEST_CASE("parse field as char", "IniFile")


### PR DESCRIPTION
It is reasonably common in configuration files for the values `0` and `1` to be considered valid values for boolean fields, and for users to expect this to be possible.  This patch adds support for parsing these values as bool.  There are no notable backward-compatibility issues introduced by this patch.