### PR TITLE
improved log to point another possible case

### DIFF
--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -640,7 +640,8 @@ namespace ini
                     {
                         std::stringstream ss;
                         ss << "l." << lineNo
-                           << ": ini parsing failed, field has no section";
+                           << ": ini parsing failed, field has no section"
+                                " or ini file in use by another application";
                         throw std::logic_error(ss.str());
                     }
 


### PR DESCRIPTION
I encountered that case while my colleague opened config file with vi (text editor). It throws exception by type of logic error, in addition that wanted to make an addition to log  to point out another possible reason of exception.