### PR TITLE
Option to throw exception when duplicate fields in section

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ int main()
 }
 ```
 
+When duplicate fields are decoded the previous value is simply overwritten by default. You can disallow duplicate fields from being overwritten by using the ```allowOverwriteDuplicateFields(false)``` function. If you do this, an exception will be thrown if a duplicate field is found inside a section.
+
+```cpp
+#include <inicpp.h>
+
+int main()
+{
+    // load an ini file
+    ini::IniFile myIni;
+    myIni.allowOverwriteDuplicateFields(false);
+    // throws an exception if the ini file has duplicate fields
+    myIni.load("some/ini/path");
+}
+```
+
 Sections and fields can be accessed using the index operator ```[]```.
 The values can be converted to various native types:
 

--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -419,6 +419,7 @@ namespace ini
         char esc_ = '\\';
         std::vector<std::string> commentPrefixes_ = { "#" , ";" };
         bool multiLineValues_ = false;
+        bool exceptionWhenDuplicateField_ = false;
 
         void eraseComment(const std::string &commentPrefix,
             std::string &str,
@@ -581,6 +582,14 @@ namespace ini
             multiLineValues_ = enable;
         }
 
+        /** Sets whether or not to throw an exception if duplicate fields are found in a section.
+          * Default is false.
+          * @param enable enable or disable? */
+        void setExceptionWhenDuplicateField(bool enable)
+        {
+            exceptionWhenDuplicateField_ = enable;
+        }
+
         /** Tries to decode a ini file from the given input stream.
           * @param is input stream from which data should be read. */
         void decode(std::istream &is)
@@ -670,6 +679,13 @@ namespace ini
                         // retrieve field name and value
                         std::string name = line.substr(0, pos);
                         trim(name);
+                        if (exceptionWhenDuplicateField_ && currentSection->count(name))
+                        {
+                            std::stringstream ss;
+                            ss << "l." << lineNo
+                               << ": ini parsing failed, duplicate field found";
+                            throw std::logic_error(ss.str());
+                        }
                         std::string value = line.substr(pos + 1, std::string::npos);
                         trim(value);
                         (*currentSection)[name] = value;

--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -419,7 +419,7 @@ namespace ini
         char esc_ = '\\';
         std::vector<std::string> commentPrefixes_ = { "#" , ";" };
         bool multiLineValues_ = false;
-        bool exceptionWhenDuplicateField_ = false;
+        bool overwriteDuplicateFields_ = true;
 
         void eraseComment(const std::string &commentPrefix,
             std::string &str,
@@ -582,12 +582,14 @@ namespace ini
             multiLineValues_ = enable;
         }
 
-        /** Sets whether or not to throw an exception if duplicate fields are found in a section.
-          * Default is false.
-          * @param enable enable or disable? */
-        void setExceptionWhenDuplicateField(bool enable)
+        /** Sets whether or not overwriting duplicate fields is allowed.
+          * If overwriting duplicate fields is not allowed,
+          * an exception is thrown when a duplicate field is found inside a section.
+          * Default is true.
+          * @param allowed Is overwriting duplicate fields allowed or not? */
+        void allowOverwriteDuplicateFields(bool allowed)
         {
-            exceptionWhenDuplicateField_ = enable;
+            overwriteDuplicateFields_ = allowed;
         }
 
         /** Tries to decode a ini file from the given input stream.
@@ -679,7 +681,7 @@ namespace ini
                         // retrieve field name and value
                         std::string name = line.substr(0, pos);
                         trim(name);
-                        if (exceptionWhenDuplicateField_ && currentSection->count(name))
+                        if (!overwriteDuplicateFields_ && currentSection->count(name) != 0)
                         {
                             std::stringstream ss;
                             ss << "l." << lineNo

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -67,6 +67,17 @@ TEST_CASE("parse section with duplicate field", "IniFile")
     REQUIRE(inif["Foo"]["bar"].as<std::string>() == "world");
 }
 
+TEST_CASE("parse section with duplicate field and exceptionWhenDuplicateField_ set to disabled", "IniFile")
+{
+    ini::IniFile inif;
+    inif.setExceptionWhenDuplicateField(false);
+    inif.decode("[Foo]\nbar=hello\nbar=world");
+
+    REQUIRE(inif.size() == 1);
+    REQUIRE(inif["Foo"].size() == 1);
+    REQUIRE(inif["Foo"]["bar"].as<std::string>() == "world");
+}
+
 TEST_CASE("parse field as bool", "IniFile")
 {
     std::istringstream ss("[Foo]\nbar1=true\nbar2=false\nbar3=tRuE");
@@ -864,4 +875,11 @@ TEST_CASE("spaces are not taken into account in sections", "IniFile")
     ini::IniFile inif(ss);
 
     REQUIRE(inif.find("Foo") != inif.end());
+}
+
+TEST_CASE("parse section with duplicate field and exceptionWhenDuplicateField_ set to enabled", "IniFile")
+{
+    ini::IniFile inif;
+    inif.setExceptionWhenDuplicateField(true);
+    REQUIRE_THROWS(inif.decode("[Foo]\nbar=hello\nbar=world"));
 }

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -67,10 +67,10 @@ TEST_CASE("parse section with duplicate field", "IniFile")
     REQUIRE(inif["Foo"]["bar"].as<std::string>() == "world");
 }
 
-TEST_CASE("parse section with duplicate field and exceptionWhenDuplicateField_ set to disabled", "IniFile")
+TEST_CASE("parse section with duplicate field and overwriteDuplicateFields_ set to true", "IniFile")
 {
     ini::IniFile inif;
-    inif.setExceptionWhenDuplicateField(false);
+    inif.allowOverwriteDuplicateFields(true);
     inif.decode("[Foo]\nbar=hello\nbar=world");
 
     REQUIRE(inif.size() == 1);
@@ -877,9 +877,9 @@ TEST_CASE("spaces are not taken into account in sections", "IniFile")
     REQUIRE(inif.find("Foo") != inif.end());
 }
 
-TEST_CASE("parse section with duplicate field and exceptionWhenDuplicateField_ set to enabled", "IniFile")
+TEST_CASE("parse section with duplicate field and overwriteDuplicateFields_ set to false", "IniFile")
 {
     ini::IniFile inif;
-    inif.setExceptionWhenDuplicateField(true);
+    inif.allowOverwriteDuplicateFields(false);
     REQUIRE_THROWS(inif.decode("[Foo]\nbar=hello\nbar=world"));
 }


### PR DESCRIPTION
### Summary
This pull request adds the option to throw an exception when a duplicate field is found inside a section.
### Problem
We need the option to detect if duplicate fields appear inside a section.
However, at the moment it is hard to detect duplicate fields inside a section after it has been decoded.
### Solution
Similar to the `multiLineValues_` option, the pull request adds `exceptionWhenDuplicateField_`. To avoid compatibility issues with prior versions, the option is disabled by default. It can be enabled and disabled with a call to `setExceptionWhenDuplicateField`. When enabled, an exception is thrown if a duplicate field is found inside a section. When disabled, no exception is thrown when duplicate fields are encountered and the previously decoded value is overwritten, which is the same behaviour as before this pull request.

To ensure correctness, two test cases have been added to test setting the option to enabled and disabled. The default case is already covered by an existing test case.