### PR TITLE
Fix make install command failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ target_include_directories(inicpp INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 add_library(inicpp::inicpp ALIAS inicpp)
-install(DIRECTORY inicpp TYPE INCLUDE)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/inicpp.h TYPE INCLUDE)
 
 if(${BUILD_TESTS})
     add_subdirectory(test)


### PR DESCRIPTION
### Problem

- Run CLI installation commands from [readme](https://github.com/Rookfighter/inifile-cpp?tab=readme-ov-file#install)

```
$ mkdir build
$ cd build/

$ cmake ..
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (0.2s)
-- Generating done (0.0s)
-- Build files have been written to: /home/wirena/Code/Build/inifile-cpp/build


$ sudo make install
Install the project...
-- Install configuration: ""
CMake Error at cmake_install.cmake:51 (file):
  file INSTALL cannot find "/home/wirena/Code/Build/inifile-cpp/inicpp": No
  such file or directory.
make: *** [Makefile:110: install] Error 1

```

- make install command tries to copy non-existing file and fails

### Toolchains:

 - OS: Linux 6.1.80-1-MANJARO
 - CMake version 3.28.3
 - gcc version 13.2.1 20230801

Also tried it on raspbian:

 - OS: Linux 6.1.21-v8+
 - CMake version 3.18.4
 - gcc version 10.2.1 20210110


Not sure if using `cmake(FILES ...` is the right way, but this works on my system. Haven't tested it on Windows