### PR TITLE
Add support for std::string_view

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: ${{matrix.config.name}}
+    name: "${{matrix.config.name}} C++${{matrix.cxx}}"
     runs-on: ${{matrix.config.os}}
     strategy:
       matrix:
@@ -27,12 +27,15 @@ jobs:
           - os: macos-latest
             name: Mac OS Release
             build_type: Release
+        cxx:
+          - 11
+          - 17
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Configure
-      run: cmake -S . -B ${{runner.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}} -DBUILD_TESTS=True -DBUILD_EXAMPLES=True
+      run: cmake -S . -B ${{runner.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}} -DBUILD_TESTS=True -DBUILD_EXAMPLES=True -DINICPP_CXX_STANDARD=${{matrix.cxx}}
     - name: Build
       run: cmake --build ${{runner.workspace}}/build --config ${{matrix.config.build_type}}
     - name: Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,9 @@ project(inifile-cpp)
 
 include(CTest)
 
-SET(CMAKE_CXX_STANDARD 11)
+set(INICPP_CXX_STANDARD "11" CACHE STRING "C++ standard to use when building tests & examples.")
+
+SET(CMAKE_CXX_STANDARD ${INICPP_CXX_STANDARD})
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(CMAKE_COMPILER_IS_GNUCXX)

--- a/include/inicpp.h
+++ b/include/inicpp.h
@@ -17,6 +17,11 @@
 #include <sstream>
 #include <stdexcept>
 #include <vector>
+#include <string>
+
+#ifdef __cpp_lib_string_view // This one is defined in <string> if we have std::string_view
+#   include <string_view>
+#endif
 
 namespace ini
 {
@@ -310,6 +315,22 @@ namespace ini
             result = value;
         }
     };
+
+#ifdef __cpp_lib_string_view
+    template<>
+    struct Convert<std::string_view>
+    {
+        void decode(const std::string &value, std::string_view &result)
+        {
+            result = value;
+        }
+
+        void encode(const std::string_view value, std::string &result)
+        {
+            result = value;
+        }
+    };
+#endif
 
     template<>
     struct Convert<const char*>

--- a/test/test_inifile.cpp
+++ b/test/test_inifile.cpp
@@ -224,6 +224,19 @@ TEST_CASE("parse field as const char*", "IniFile")
     REQUIRE(std::strcmp(inif["Foo"]["bar2"].as<const char*>(), "world") == 0);
 }
 
+#ifdef __cpp_lib_string_view
+TEST_CASE("parse field as std::string_view", "IniFile")
+{
+    std::istringstream ss("[Foo]\nbar1=hello\nbar2=world");
+    ini::IniFile inif(ss);
+
+    REQUIRE(inif.size() == 1);
+    REQUIRE(inif["Foo"].size() == 2);
+    REQUIRE(inif["Foo"]["bar1"].as<std::string_view>() == "hello");
+    REQUIRE(inif["Foo"]["bar2"].as<std::string_view>() == "world");
+}
+#endif
+
 TEST_CASE("parse field with custom field sep", "IniFile")
 {
     std::istringstream ss("[Foo]\nbar1:true\nbar2:false\nbar3:tRuE");
@@ -536,6 +549,18 @@ TEST_CASE("save with string literal fields", "IniFile")
     std::string result = inif.encode();
     REQUIRE(result == "[Foo]\nbar1=hello\nbar2=world\n");
 }
+
+#ifdef __cpp_lib_string_view
+TEST_CASE("save with std::string_view fields", "IniFile")
+{
+    ini::IniFile inif;
+    inif["Foo"]["bar1"] = std::string_view("hello");
+    inif["Foo"]["bar2"] = std::string_view("world");
+
+    std::string result = inif.encode();
+    REQUIRE(result == "[Foo]\nbar1=hello\nbar2=world\n");
+}
+#endif
 
 TEST_CASE("save with custom field sep", "IniFile")
 {


### PR DESCRIPTION
This is a saner way to query ini values w/o copying the strings around for us people living in 2024.

Changes:
* Added `Convert<std::string_view>` specialization, conditional on `std::string_view` being available.
* Added tests for it.
* Running GH tests in C++11 and C++17 modes.
